### PR TITLE
Small change on text that causing confusion when executed on terminal

### DIFF
--- a/Command/ServiceStartCommand.php
+++ b/Command/ServiceStartCommand.php
@@ -29,10 +29,10 @@ class ServiceStartCommand extends ContainerAwareCommand
             $output->writeln('The command is already running in another process.');
             return;
         }
-        $output->writeln(sprintf('[%s %s] ................... Running', date('Y-m-d H:i:s'), self::COMMAND_NAME));
+        $output->writeln(sprintf('[%s %s] ................... Starting', date('Y-m-d H:i:s'), self::COMMAND_NAME));
         $loader = $this->getContainer()->get('cmobi_msf.service.loader');
         $loader->run();
 
-        $output->writeln(sprintf('[%s %s] ................... Exiting', date('Y-m-d H:i:s'), self::COMMAND_NAME));
+        $output->writeln(sprintf('[%s %s] ................... Running', date('Y-m-d H:i:s'), self::COMMAND_NAME));
     }
 }


### PR DESCRIPTION
This text was changed because it's causing confusion when we run, because display this text.

```bash
dev@ci08:~/source/random-microservice$ app/console cmobi:microservice:run
[2017-02-24 12:00:52 cmobi:microservice:run] ................... Running
[2017-02-24 12:00:52 cmobi:microservice:run] ................... Exiting
dev@ci08:~/source/random-microservice$
```

This `Exiting` Makes it appear that the command failed, like nginx, but was executed with success, then, was changed as below:

```bash
dev@ci08:~/source/random-microservice$ app/console cmobi:microservice:run
[2017-02-24 12:01:36 cmobi:microservice:run] ................... Starting
[2017-02-24 12:01:36 cmobi:microservice:run] ................... Running
dev@ci08:~/source/random-microservice$
```